### PR TITLE
Enhance wire model assertion

### DIFF
--- a/src/CustomLivewireAssertionsMixin.php
+++ b/src/CustomLivewireAssertionsMixin.php
@@ -6,6 +6,9 @@ use Closure;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\Assert as PHPUnit;
 
+/**
+ * @mixin \Livewire\Testing\TestableLivewire
+ */
 class CustomLivewireAssertionsMixin
 {
     public function assertPropertyWired(): Closure

--- a/src/CustomLivewireAssertionsMixin.php
+++ b/src/CustomLivewireAssertionsMixin.php
@@ -14,8 +14,8 @@ class CustomLivewireAssertionsMixin
     public function assertPropertyWired(): Closure
     {
         return function (string $property) {
-            PHPUnit::assertStringContainsString(
-                'wire:model="'.$property.'"',
+            PHPUnit::assertMatchesRegularExpression(
+                '/wire:model(\.(lazy|defer))*="'.$property.'"/',
                 $this->stripOutInitialData($this->lastRenderedDom)
             );
 

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -11,7 +11,7 @@ use Livewire\LivewireServiceProvider;
 
 class AssertionsTest extends TestCase
 {
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return [
             LivewireServiceProvider::class,

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -23,7 +23,9 @@ class AssertionsTest extends TestCase
     public function it_checks_if_livewire_property_is_wired_to_a_field(): void
     {
         Livewire::test(LivewireTestComponentA::class)
-            ->assertPropertyWired('user');
+            ->assertPropertyWired('user')
+            ->assertPropertyWired('lazy')
+            ->assertPropertyWired('defer');
     }
 
     /** @test * */

--- a/tests/resources/views/livewire-test-component-a.php
+++ b/tests/resources/views/livewire-test-component-a.php
@@ -1,5 +1,7 @@
 <div>
     <input type="text" wire:model="user" />
+    <input type="text" wire:model.lazy="lazy" />
+    <input type="text" wire:model.defer="defer" />
     <x-button wire:click="submit" />
 
     <p>First value</p>


### PR DESCRIPTION
Currently `assertPropertyWired('foo')` only checks for `wire:model="foo"`

This PR adds the ability to match also `wire:model.defer="foo"` or `wire:model.lazy="foo"`