### PR TITLE
Added support for wire:model with custom duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Livewire::test(FeedbackForm::class)
     ->assertPropertyWired('email');
 ```
 
-It looks for a string like `wire:model="email"` in your components's view file. It also detects variations like `wire:model.defer="email"`, `wire:model.lazy="email"`, `wire:model.defer.500ms="email"` or `wire:model.lazy.500s="email"`.
+It looks for a string like `wire:model="email"` in your components's view file. It also detects variations like `wire:model.defer="email"`, `wire:model.lazy="email"`, `wire:model.debounce="email"`, `wire:model.lazy.10s="email"` or `wire:model.debounce.500ms="email"`.
 
 ### Check if a Livewire method is wired to an HTML field
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Livewire::test(FeedbackForm::class)
     ->assertPropertyWired('email');
 ```
 
-It looks for a string like `wire:model="email"` in your components's view file. It also detects variations like `wire:model.defer="email"` or `wire:model.lazy="email"`.
+It looks for a string like `wire:model="email"` in your components's view file. It also detects variations like `wire:model.defer="email"`, `wire:model.lazy="email"`, `wire:model.defer.500ms="email"` or `wire:model.lazy.500s="email"`.
 
 ### Check if a Livewire method is wired to an HTML field
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^7.4|^8.0",
         "spatie/laravel-package-tools": "^1.4.3",
         "illuminate/support": "^8.0"
     },

--- a/src/CustomLivewireAssertionsMixin.php
+++ b/src/CustomLivewireAssertionsMixin.php
@@ -15,7 +15,7 @@ class CustomLivewireAssertionsMixin
     {
         return function (string $property) {
             PHPUnit::assertMatchesRegularExpression(
-                '/wire:model(\.(lazy|defer)(\.\d+?(ms|s)|))*="'.$property.'"/',
+                '/wire:model(\.(defer|(lazy|debounce)(\.\d+?(ms|s)|)))*="'.$property.'"/',
                 $this->stripOutInitialData($this->lastRenderedDom)
             );
 

--- a/src/CustomLivewireAssertionsMixin.php
+++ b/src/CustomLivewireAssertionsMixin.php
@@ -15,7 +15,7 @@ class CustomLivewireAssertionsMixin
     {
         return function (string $property) {
             PHPUnit::assertMatchesRegularExpression(
-                '/wire:model(\.(lazy|defer))*="'.$property.'"/',
+                '/wire:model(\.(lazy|defer)(\.\d+?(ms|s)|))*="'.$property.'"/',
                 $this->stripOutInitialData($this->lastRenderedDom)
             );
 

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -25,7 +25,9 @@ class AssertionsTest extends TestCase
         Livewire::test(LivewireTestComponentA::class)
             ->assertPropertyWired('user')
             ->assertPropertyWired('lazy')
-            ->assertPropertyWired('defer');
+            ->assertPropertyWired('defer')
+            ->assertPropertyWired('lazy-with-duration')
+            ->assertPropertyWired('defer-with-duration');
     }
 
     /** @test * */

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -26,8 +26,9 @@ class AssertionsTest extends TestCase
             ->assertPropertyWired('user')
             ->assertPropertyWired('lazy')
             ->assertPropertyWired('defer')
+            ->assertPropertyWired('debounce')
             ->assertPropertyWired('lazy-with-duration')
-            ->assertPropertyWired('defer-with-duration');
+            ->assertPropertyWired('debounce-with-duration');
     }
 
     /** @test * */

--- a/tests/resources/views/livewire-test-component-a.php
+++ b/tests/resources/views/livewire-test-component-a.php
@@ -2,6 +2,8 @@
     <input type="text" wire:model="user" />
     <input type="text" wire:model.lazy="lazy" />
     <input type="text" wire:model.defer="defer" />
+    <input type="text" wire:model.lazy.200s="lazy-with-duration" />
+    <input type="text" wire:model.defer.500ms="defer-with-duration" />
     <x-button wire:click="submit" />
 
     <p>First value</p>

--- a/tests/resources/views/livewire-test-component-a.php
+++ b/tests/resources/views/livewire-test-component-a.php
@@ -2,8 +2,9 @@
     <input type="text" wire:model="user" />
     <input type="text" wire:model.lazy="lazy" />
     <input type="text" wire:model.defer="defer" />
+    <input type="text" wire:model.debounce="debounce" />
     <input type="text" wire:model.lazy.200s="lazy-with-duration" />
-    <input type="text" wire:model.defer.500ms="defer-with-duration" />
+    <input type="text" wire:model.debounce.500ms="defer-with-duration" />
     <x-button wire:click="submit" />
 
     <p>First value</p>

--- a/tests/resources/views/livewire-test-component-a.php
+++ b/tests/resources/views/livewire-test-component-a.php
@@ -4,7 +4,7 @@
     <input type="text" wire:model.defer="defer" />
     <input type="text" wire:model.debounce="debounce" />
     <input type="text" wire:model.lazy.200s="lazy-with-duration" />
-    <input type="text" wire:model.debounce.500ms="defer-with-duration" />
+    <input type="text" wire:model.debounce.500ms="debounce-with-duration" />
     <x-button wire:click="submit" />
 
     <p>First value</p>


### PR DESCRIPTION
This PR will add support to `assertPropertyWired` to also validate `wire:model` with a custom duration for `.lazy` and `.debounce`.  

I also added the missing `wire:model.debounce` modifier.

You can see how it works in Livewire in this Javascript file: [wire-directives.js](https://github.com/livewire/livewire/blob/2f06b28be0aa0d5bf0a4598b4b571d7d1a24e5c1/js/util/wire-directives.js#L69)