### PR TITLE
Add support for livewire blade directive

### DIFF
--- a/src/CustomLivewireAssertionsMixin.php
+++ b/src/CustomLivewireAssertionsMixin.php
@@ -40,11 +40,14 @@ class CustomLivewireAssertionsMixin
         return function (string $componentNeedleClass) {
             $componentNeedle = Str::of($componentNeedleClass)
                 ->classBasename()
-                ->kebab()
-                ->prepend('<livewire:');
+                ->kebab();
 
             $componentHaystackView = file_get_contents($this->lastRenderedView->getPath());
-            PHPUnit::assertStringContainsString($componentNeedle, $componentHaystackView);
+
+            PHPUnit::assertMatchesRegularExpression(
+                '/@livewire\(\''.$componentNeedle.'\'|<livewire\:'.$componentNeedle.'/',
+                $componentHaystackView
+            );
 
             return $this;
         };

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -5,6 +5,7 @@ namespace Christophrumpel\MissingLivewireAssertions\Tests;
 use Christophrumpel\MissingLivewireAssertions\MissingLivewireAssertionsServiceProvider;
 use Christophrumpel\MissingLivewireAssertions\Tests\Components\LivewireTestComponentA;
 use Christophrumpel\MissingLivewireAssertions\Tests\Components\LivewireTestComponentB;
+use Christophrumpel\MissingLivewireAssertions\Tests\Components\LivewireTestComponentC;
 use Christophrumpel\MissingLivewireAssertions\Tests\View\Components\Button;
 use Livewire\Livewire;
 use Livewire\LivewireServiceProvider;
@@ -72,5 +73,12 @@ class AssertionsTest extends TestCase
     {
         Livewire::test(LivewireTestComponentA::class)
             ->assertSeeBefore('First value', 'Second value');
+    }
+
+    /** @test * */
+    public function it_checks_if_it_sees_a_blade_directive(): void
+    {
+        Livewire::test(LivewireTestComponentC::class)
+            ->assertContainsLivewireComponent(LivewireTestComponentB::class);
     }
 }

--- a/tests/Components/LivewireTestComponentC.php
+++ b/tests/Components/LivewireTestComponentC.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Christophrumpel\MissingLivewireAssertions\Tests\Components;
+
+use Livewire\Component;
+
+class LivewireTestComponentC extends Component
+{
+    public function render()
+    {
+        return view('livewire-test-component-c');
+    }
+}

--- a/tests/Components/livewire-test-component-b.php
+++ b/tests/Components/livewire-test-component-b.php
@@ -1,0 +1,3 @@
+<div>
+    <p>Livewire Test Component B</p>
+</div>

--- a/tests/resources/views/livewire-test-component-c.php
+++ b/tests/resources/views/livewire-test-component-c.php
@@ -1,0 +1,3 @@
+<div>
+    @livewire('livewire-test-component-b')
+</div>


### PR DESCRIPTION
# Setup:

Livewire component view file with the following content: 
```blade 
@livewire('component-x')
```

Testcase:
```php
 Livewire::test(LivewireTestComponentC::class)
            ->assertContainsLivewireComponent(LivewireComponentX::class);
```

# Current situation:
Test will fail cause the test method does not check for the appearance of the @ directive tags.

# Changes:

The assert method will create regex for both appearances. That allows the useage of both.