### PR TITLE
Parses properties and methods enclosed in single quotes and double quotes

### DIFF
--- a/src/CustomLivewireAssertionsMixin.php
+++ b/src/CustomLivewireAssertionsMixin.php
@@ -15,7 +15,7 @@ class CustomLivewireAssertionsMixin
     {
         return function (string $property) {
             PHPUnit::assertMatchesRegularExpression(
-                '/wire:model(\.(defer|(lazy|debounce)(\.\d+?(ms|s)|)))*="'.$property.'"/',
+                '/wire:model(\.(defer|(lazy|debounce)(\.\d+?(ms|s)|)))*=(?<q>"|\')'.$property.'(\k\'q\')/',
                 $this->stripOutInitialData($this->lastRenderedDom)
             );
 
@@ -27,7 +27,7 @@ class CustomLivewireAssertionsMixin
     {
         return function (string $method) {
             PHPUnit::assertMatchesRegularExpression(
-                '/wire:click(\.(prevent))*="'.$method.'(\s*\(.+\)\s*)?\s*"/',
+                '/wire:click(\.(prevent))*=(?<q>"|\')'.$method.'(\s*\(.+\)\s*)?\s*(\k\'q\')/',
                 $this->stripOutInitialData($this->lastRenderedDom)
             );
 
@@ -39,7 +39,7 @@ class CustomLivewireAssertionsMixin
     {
         return function (string $method) {
             PHPUnit::assertMatchesRegularExpression(
-                '/wire:submit(\.(prevent))*="'.$method.'"/',
+                '/wire:submit(\.(prevent))*=(?<q>"|\')'.$method.'(\k\'q\')/',
                 $this->stripOutInitialData($this->lastRenderedDom)
             );
 

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -29,7 +29,8 @@ class AssertionsTest extends TestCase
             ->assertPropertyWired('defer')
             ->assertPropertyWired('debounce')
             ->assertPropertyWired('lazy-with-duration')
-            ->assertPropertyWired('debounce-with-duration');
+            ->assertPropertyWired('debounce-with-duration')
+            ->assertPropertyWired('singlequote');
     }
 
     /** @test * */
@@ -37,7 +38,8 @@ class AssertionsTest extends TestCase
     {
         Livewire::test(LivewireTestComponentA::class)
             ->assertMethodWired('prevent')
-            ->assertMethodWired('submit');
+            ->assertMethodWired('submit')
+            ->assertMethodWired('singlequote');
     }
 
     /** @test * */
@@ -52,7 +54,8 @@ class AssertionsTest extends TestCase
     public function it_checks_if_livewire_method_is_wired_to_a_form(): void
     {
         Livewire::test(LivewireTestComponentA::class)
-            ->assertMethodWiredToForm('upload');
+            ->assertMethodWiredToForm('upload')
+            ->assertMethodWiredToForm('uploadSinglequote');
     }
 
     /** @test * */

--- a/tests/resources/views/livewire-test-component-a.php
+++ b/tests/resources/views/livewire-test-component-a.php
@@ -5,9 +5,10 @@
     <input type="text" wire:model.debounce="debounce" />
     <input type="text" wire:model.lazy.200s="lazy-with-duration" />
     <input type="text" wire:model.debounce.500ms="debounce-with-duration" />
+    <input type="text" wire:model='singlequote' />
     <a href="/test" wire:click.prevent="prevent">test</a>
     <x-button wire:click="submit" />
-
+    <x-button wire:click='singlequote' />
     <x-button wire:click="params({{$prop}}, 42)" />
     <a href="/test" wire:click.prevent="preventParams({{$prop}}, 42)">test</a>
 
@@ -21,5 +22,8 @@
 
 
         <button type="submit">Upload Participants</button>
+    </form>
+
+    <form wire:submit.prevent='uploadSinglequote'>
     </form>
 </div>


### PR DESCRIPTION
Fixes #10 - detection of properties and methods wraped in both single and double quotes for assertions `assertMethodWired`, `assertPropertyWired` and `assertMethodWiredToForm`. Will not match mismatched quote usage e.g. `wire:model='attribute"`