### PR TITLE
Added methods to test the opposite conditions (fixes issue #14)

### DIFF
--- a/src/CustomLivewireAssertionsMixin.php
+++ b/src/CustomLivewireAssertionsMixin.php
@@ -23,6 +23,21 @@ class CustomLivewireAssertionsMixin
         };
     }
 
+    /**
+     * Assert that the given property is NOT wired
+     */
+    public function assertPropertyNotWired(): Closure
+    {
+        return function (string $property) {
+            PHPUnit::assertDoesNotMatchRegularExpression(
+                '/wire:model(\.(defer|(lazy|debounce)(\.\d+?(ms|s)|)))*=(?<q>"|\')'.$property.'(\k\'q\')/',
+                $this->stripOutInitialData($this->lastRenderedDom)
+            );
+
+            return $this;
+        };
+    }
+
     public function assertPropertyEntangled(): Closure
     {
         return function (string $property) {
@@ -44,6 +59,30 @@ class CustomLivewireAssertionsMixin
         };
     }
 
+    /**
+     * Assert that the given property is NOT entangled
+     */
+    public function assertPropertyNotEntangled(): Closure
+    {
+        return function (string $property) {
+            $propertyRe = '('
+                . preg_quote(htmlspecialchars("'" . $property . "'", ENT_QUOTES))
+                . '|'
+                . preg_quote(htmlspecialchars('"' . $property . '"', ENT_QUOTES))
+                . '|'
+                . preg_quote('"' . $property . '"')
+                . '|'
+                . preg_quote("'" . $property . "'")
+                . ')';
+            PHPUnit::assertDoesNotMatchRegularExpression(
+                '/(@|\$wire\.)entangle\('.$propertyRe.'\)/',
+                $this->stripOutInitialData($this->lastRenderedDom)
+            );
+
+            return $this;
+        };
+    }
+
     public function assertMethodWired(): Closure
     {
         return function (string $method) {
@@ -56,10 +95,40 @@ class CustomLivewireAssertionsMixin
         };
     }
 
+    /**
+     * Assert that the given method is NOT wired
+     */
+    public function assertMethodNotWired(): Closure
+    {
+        return function (string $method) {
+            PHPUnit::assertDoesNotMatchRegularExpression(
+                '/wire:click(\.(prevent))*=(?<q>"|\')'.$method.'(\s*\(.+\)\s*)?\s*(\k\'q\')/',
+                $this->stripOutInitialData($this->lastRenderedDom)
+            );
+
+            return $this;
+        };
+    }
+
     public function assertMethodWiredToForm(): Closure
     {
         return function (string $method) {
             PHPUnit::assertMatchesRegularExpression(
+                '/wire:submit(\.(prevent))*=(?<q>"|\')'.$method.'(\k\'q\')/',
+                $this->stripOutInitialData($this->lastRenderedDom)
+            );
+
+            return $this;
+        };
+    }
+
+    /**
+     * Assert that the given method is NOT wired to form
+     */
+    public function assertMethodNotWiredToForm(): Closure
+    {
+        return function (string $method) {
+            PHPUnit::assertDoesNotMatchRegularExpression(
                 '/wire:submit(\.(prevent))*=(?<q>"|\')'.$method.'(\k\'q\')/',
                 $this->stripOutInitialData($this->lastRenderedDom)
             );
@@ -86,6 +155,27 @@ class CustomLivewireAssertionsMixin
         };
     }
 
+    /**
+     * Assert that the given Livewire component is NOT contained
+     */
+    public function assertDoesNotContainLivewireComponent(): Closure
+    {
+        return function (string $componentNeedleClass) {
+            $componentNeedle = Str::of($componentNeedleClass)
+                ->classBasename()
+                ->kebab();
+
+            $componentHaystackView = file_get_contents($this->lastRenderedView->getPath());
+
+            PHPUnit::assertDoesNotMatchRegularExpression(
+                '/@livewire\(\''.$componentNeedle.'\'|<livewire\:'.$componentNeedle.'/',
+                $componentHaystackView
+            );
+
+            return $this;
+        };
+    }
+
     public function assertContainsBladeComponent(): Closure
     {
         return function (string $componentNeedleClass) {
@@ -101,6 +191,24 @@ class CustomLivewireAssertionsMixin
         };
     }
 
+    /**
+     * Assert that the given Blade component is NOT contained
+     */
+    public function assertDoesNotContainBladeComponent(): Closure
+    {
+        return function (string $componentNeedleClass) {
+            $componentNeedle = Str::of($componentNeedleClass)
+                ->classBasename()
+                ->kebab()
+                ->prepend('<x-');
+
+            $componentHaystackView = file_get_contents($this->lastRenderedView->getPath());
+            PHPUnit::assertStringNotContainsString($componentNeedle, $componentHaystackView);
+
+            return $this;
+        };
+    }
+
     public function assertSeeBefore(): Closure
     {
         return function ($valueBefore, $valueAfter) {
@@ -109,6 +217,22 @@ class CustomLivewireAssertionsMixin
             PHPUnit::assertNotFalse($valueAfterPosition = mb_strpos($html, $valueAfter), "Value: $valueAfter not given in haystack.");
 
             PHPUnit::assertTrue($valueBeforePosition < $valueAfterPosition, "$valueBefore does occur before $valueAfter.");
+
+            return $this;
+        };
+    }
+
+    /**
+     * Assert that the given valueBefore string is NOT before valueAfter string
+     */
+    public function assertDoNotSeeBefore(): Closure
+    {
+        return function ($valueBefore, $valueAfter) {
+            $html = $this->stripOutInitialData($this->lastRenderedDom);
+            PHPUnit::assertNotFalse($valueBeforePosition = mb_strpos($html, $valueBefore), "Value: $valueBefore not given in haystack.");
+            PHPUnit::assertNotFalse($valueAfterPosition = mb_strpos($html, $valueAfter), "Value: $valueAfter not given in haystack.");
+
+            PHPUnit::assertFalse($valueBeforePosition < $valueAfterPosition, "$valueBefore does occur before $valueAfter.");
 
             return $this;
         };

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -34,6 +34,19 @@ class AssertionsTest extends TestCase
     }
 
     /** @test * */
+    public function it_checks_if_livewire_property_is_not_wired_to_a_field(): void
+    {
+        Livewire::test(LivewireTestComponentA::class)
+            ->assertPropertyNotWired('user_not_wired')
+            ->assertPropertyNotWired('lazy_not_wired')
+            ->assertPropertyNotWired('defer_not_wired')
+            ->assertPropertyNotWired('debounce_not_wired')
+            ->assertPropertyNotWired('lazy-with-duration_not_wired')
+            ->assertPropertyNotWired('debounce-with-duration_not_wired')
+            ->assertPropertyNotWired('singlequote_not_wired');
+    }
+
+    /** @test * */
     public function it_checks_if_livewire_property_is_entangled_to_a_field(): void
     {
         Livewire::test(LivewireTestComponentA::class)
@@ -41,6 +54,16 @@ class AssertionsTest extends TestCase
             ->assertPropertyEntangled('entangled-x-data-state-double-quote')
             ->assertPropertyEntangled('entangled-x-data-single-quote')
             ->assertPropertyEntangled('entangled-x-data-single-quote');
+    }
+
+    /** @test * */
+    public function it_checks_if_livewire_property_is_not_entangled_to_a_field(): void
+    {
+        Livewire::test(LivewireTestComponentA::class)
+            ->assertPropertyNotEntangled('entangled-x-data-state-single-quote-not-entangled')
+            ->assertPropertyNotEntangled('entangled-x-data-state-double-quote-not-entangled')
+            ->assertPropertyNotEntangled('entangled-x-data-single-quote-not-entangled')
+            ->assertPropertyNotEntangled('entangled-x-data-single-quote-not-entangled');
     }
 
     /** @test * */
@@ -53,11 +76,28 @@ class AssertionsTest extends TestCase
     }
 
     /** @test * */
+    public function it_checks_if_livewire_method_is_not_wired_to_a_field(): void
+    {
+        Livewire::test(LivewireTestComponentA::class)
+            ->assertMethodNotWired('prevent_not_wired')
+            ->assertMethodNotWired('submit_not_wired')
+            ->assertMethodNotWired('singlequote_not_wired');
+    }
+
+    /** @test * */
     public function it_checks_if_livewire_method_is_wired_with_params_to_a_field(): void
     {
         Livewire::test(LivewireTestComponentA::class)
             ->assertMethodWired('params')
             ->assertMethodWired('preventParams');
+    }
+
+    /** @test * */
+    public function it_checks_if_livewire_method_is_not_wired_with_params_to_a_field(): void
+    {
+        Livewire::test(LivewireTestComponentA::class)
+            ->assertMethodNotWired('params_not_wired')
+            ->assertMethodNotWired('preventParams_not_wired');
     }
 
     /** @test * */
@@ -69,10 +109,25 @@ class AssertionsTest extends TestCase
     }
 
     /** @test * */
+    public function it_checks_if_livewire_method_is_not_wired_to_a_form(): void
+    {
+        Livewire::test(LivewireTestComponentA::class)
+            ->assertMethodNotWiredToForm('upload_not_wired')
+            ->assertMethodNotWiredToForm('uploadSinglequote_not_wired');
+    }
+
+    /** @test * */
     public function it_checks_if_livewire_component_contains_another_livewire_component_by_class_name(): void
     {
         Livewire::test(LivewireTestComponentA::class)
             ->assertContainsLivewireComponent(LivewireTestComponentB::class);
+    }
+
+    /** @test * */
+    public function it_checks_if_livewire_component_does_not_contain_another_livewire_component_by_class_name(): void
+    {
+        Livewire::test(LivewireTestComponentA::class)
+            ->assertDoesNotContainLivewireComponent(NonExistantLivewireTestComponent::class);
     }
 
     /** @test * */
@@ -83,10 +138,24 @@ class AssertionsTest extends TestCase
     }
 
     /** @test * */
+    public function it_checks_if_livewire_component_does_not_contain_another_livewire_component_by_component_name(): void
+    {
+        Livewire::test(LivewireTestComponentA::class)
+            ->assertDoesNotContainLivewireComponent('non-existant-livewire-test-component');
+    }
+
+    /** @test * */
     public function it_checks_if_livewire_component_contains_a_blade_component_by_class_name(): void
     {
         Livewire::test(LivewireTestComponentA::class)
             ->assertContainsBladeComponent(Button::class);
+    }
+
+    /** @test * */
+    public function it_checks_if_livewire_component_does_not_contain_a_blade_component_by_class_name(): void
+    {
+        Livewire::test(LivewireTestComponentA::class)
+            ->assertDoesNotContainBladeComponent(NonExistantButton::class);
     }
 
     /** @test * */
@@ -97,10 +166,24 @@ class AssertionsTest extends TestCase
     }
 
     /** @test * */
+    public function it_checks_if_livewire_component_does_not_contain_a_blade_component_by_component_name(): void
+    {
+        Livewire::test(LivewireTestComponentA::class)
+            ->assertDoesNotContainBladeComponent('non-existant-button');
+    }
+
+    /** @test * */
     public function it_checks_if_it_sees_string_before_other_string(): void
     {
         Livewire::test(LivewireTestComponentA::class)
             ->assertSeeBefore('First value', 'Second value');
+    }
+
+    /** @test * */
+    public function it_checks_if_it_does_not_see_string_before_other_string(): void
+    {
+        Livewire::test(LivewireTestComponentA::class)
+            ->assertDoNotSeeBefore('Second value', 'First value');
     }
 
     /** @test * */
@@ -109,4 +192,10 @@ class AssertionsTest extends TestCase
         Livewire::test(LivewireTestComponentC::class)
             ->assertContainsLivewireComponent(LivewireTestComponentB::class);
     }
-}
+
+    /** @test * */
+    public function it_checks_if_it_does_not_see_a_blade_directive(): void
+    {
+        Livewire::test(LivewireTestComponentC::class)
+            ->assertDoesNotContainLivewireComponent(NonExistantLivewireTestComponent::class);
+    }}


### PR DESCRIPTION
Using `PHPUnit::assertMatchesRegularExpression` and `assertStringNotContainsString` the following assertion methods were created.

Code is mostly duplicated, as I didn't want to make a major change, but logic could be extracted to protected methods to avoid duplication.

- assertPropertyNotWired
- assertPropertyNotEntangled
- assertMethodNotWired
- assertMethodNotWiredToForm
- assertDoesNotContainLivewireComponent
- assertDoesNotContainBladeComponent
- assertDoNotSeeBefore