### PR TITLE
Fix bad indentation in run-tests.yml

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         php: [8.0, 8.1, 8.2]
         laravel: ["10.x", "9.x"]
-      include:
+        include:
         - laravel: 9.x
           testbench: ^7.4
         - laravel: 10.x

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,9 +17,9 @@ jobs:
         laravel: ["10.x", "9.x"]
         include:
           - laravel: 9.x
-            testbench: ^7.4
+            testbench: ~7.4
           - laravel: 10.x
-            testbench: ^8.0
+            testbench: 8.x
         exclude:
           - laravel: 10.x
             php: 8.0

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
         laravel: ["10.x", "9.x"]
         include:
           - laravel: 9.x
-            testbench: ~7.4
+            testbench: 7.x
           - laravel: 10.x
             testbench: 8.x
         exclude:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,7 @@ jobs:
           - laravel: 10.x
             php: 8.0
 
-    name: P${{ matrix.php }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,10 +16,13 @@ jobs:
         php: [8.0, 8.1, 8.2]
         laravel: ["10.x", "9.x"]
         include:
-        - laravel: 9.x
-          testbench: ^7.4
-        - laravel: 10.x
-          testbench: ^8.0
+          - laravel: 9.x
+            testbench: ^7.4
+          - laravel: 10.x
+            testbench: ^8.0
+        exclude:
+          - laravel: 10.x
+            php: 8.0
 
     name: P${{ matrix.php }} - ${{ matrix.os }}
 


### PR DESCRIPTION
😓 sorry, PHPStorm likes to screw up my YAML files.

It also excludes PHP 8.0 and Laravel 10.x being tested and Adds the Laravel version to the matrix name.