### PR TITLE
Add Blur to propertyWired assertions

### DIFF
--- a/src/CustomLivewireAssertionsMixin.php
+++ b/src/CustomLivewireAssertionsMixin.php
@@ -15,7 +15,7 @@ class CustomLivewireAssertionsMixin
     {
         return function (string $property) {
             PHPUnit::assertMatchesRegularExpression(
-                '/wire:model(\.(live|(lazy|debounce)(\.\d+?(ms|s)|)))*=(?<q>"|\')'.$property.'(\k\'q\')/',
+                '/wire:model(\.(live|blur|(lazy|debounce)(\.\d+?(ms|s)|)))*=(?<q>"|\')'.$property.'(\k\'q\')/',
                 $this->html()
             );
 
@@ -30,7 +30,7 @@ class CustomLivewireAssertionsMixin
     {
         return function (string $property) {
             PHPUnit::assertDoesNotMatchRegularExpression(
-                '/wire:model(\.(live|(lazy|debounce)(\.\d+?(ms|s)|)))*=(?<q>"|\')'.$property.'(\k\'q\')/',
+                '/wire:model(\.(live|blur|(lazy|debounce)(\.\d+?(ms|s)|)))*=(?<q>"|\')'.$property.'(\k\'q\')/',
                 $this->html()
             );
 

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -25,6 +25,7 @@ class AssertionsTest extends TestCase
     {
         Livewire::test(LivewireTestComponentA::class)
             ->assertPropertyWired('user')
+            ->assertPropertyWired('blur')
             ->assertPropertyWired('lazy')
             ->assertPropertyWired('live')
             ->assertPropertyWired('debounce')
@@ -39,6 +40,7 @@ class AssertionsTest extends TestCase
     {
         Livewire::test(LivewireTestComponentA::class)
             ->assertPropertyNotWired('user_not_wired')
+            ->assertPropertyNotWired('blur_not_wired')
             ->assertPropertyNotWired('lazy_not_wired')
             ->assertPropertyNotWired('live_not_wired')
             ->assertPropertyNotWired('debounce_not_wired')

--- a/tests/resources/views/livewire-test-component-a.php
+++ b/tests/resources/views/livewire-test-component-a.php
@@ -1,5 +1,6 @@
 <div>
     <input type="text" wire:model="user" />
+    <input type="text" wire:model.blur="blur" />
     <input type="text" wire:model.lazy="lazy" />
     <input type="text" wire:model.live="live" />
     <input type="text" wire:model.debounce="debounce" />


### PR DESCRIPTION
This PR allows the user to have [wire:model.blur](https://livewire.laravel.com/docs/forms#only-updating-fields-on-blur) in their Livewire and still have `assertPropertyWired` return correctly.

Prior Behavior:
- If a user has `wire:model.blur="blur"` in their livewire view
- And the user writes a test with `->assertPropertyWired('blur')`
- The test will fail as `wire:model.blur` does not meet regex expression

What's Changed:
- Added `blur|` to the regex in:
- `assertPropertyWired`
- `assertPropertyNotWired`