### PR TITLE
Adds support for magic actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ It looks for a string like `wire:model="email"` in your component's view file. I
 Livewire::test(FeedbackForm::class)
     ->assertMethodWired('submit');
 ```
+It looks for a string like `wire:click="submit"` in your component's view file. 
+
+### Check is a Livewire magic action is wired to an HTML field
+```php
+Livewire::test(FeedbackForm::class)
+    ->assertMethodWired('$toggle(\'sortAsc\')');
+```
+
+It looks for a string like `wire:click="$refresh"`, `wire:click="$toggle('sortAsc')`, `$dispatch('post-created')`, along with all other [magic actions](https://livewire.laravel.com/docs/actions#magic-actions). When testing for magic actions, you must escape single quotes like shown above.
 
 ### Check if a Livewire method is wired to an HTML form
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Livewire::test(FeedbackForm::class)
 ```
 It looks for a string like `wire:click="submit"` in your component's view file. 
 
-### Check is a Livewire magic action is wired to an HTML field
+### Check if a Livewire magic action is wired to an HTML field
 ```php
 Livewire::test(FeedbackForm::class)
     ->assertMethodWired('$toggle(\'sortAsc\')');

--- a/src/CustomLivewireAssertionsMixin.php
+++ b/src/CustomLivewireAssertionsMixin.php
@@ -93,7 +93,7 @@ class CustomLivewireAssertionsMixin
     {
         return function (string $method) {
             PHPUnit::assertMatchesRegularExpression(
-                '/wire:click(\.(prevent))*=(?<q>"|\')'.$method.'(\s*\(.+\)\s*)?\s*(\k\'q\')/',
+                '/wire:click(\.(prevent))?=(?<q>"|\')'.preg_quote($method).'(\s*\(.+\)\s*)?\s*(\k\'q\')/',
                 $this->html()
             );
 
@@ -108,7 +108,7 @@ class CustomLivewireAssertionsMixin
     {
         return function (string $method) {
             PHPUnit::assertDoesNotMatchRegularExpression(
-                '/wire:click(\.(prevent))*=(?<q>"|\')'.$method.'(\s*\(.+\)\s*)?\s*(\k\'q\')/',
+                '/wire:click(\.(prevent))?=(?<q>"|\')'.preg_quote($method).'(\s*\(.+\)\s*)?\s*(\k\'q\')/',
                 $this->html()
             );
 

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -75,7 +75,14 @@ class AssertionsTest extends TestCase
         Livewire::test(LivewireTestComponentA::class)
             ->assertMethodWired('prevent')
             ->assertMethodWired('submit')
-            ->assertMethodWired('singlequote');
+            ->assertMethodWired('singlequote')
+            ->assertMethodWired('$refresh')
+            ->assertMethodWired('$toggle(\'sortAsc\')')
+            ->assertMethodWired('$dispatch(\'post-created\')')
+            ->assertMethodWired('search($event.target.value)')
+            ->assertMethodWired('$wire.$refresh()')
+            ->assertMethodWired('$parent.removePost({{ $post->id }})')
+            ->assertMethodWired('$set(\'query\', \'\')');
     }
 
     /** @test * */

--- a/tests/resources/views/livewire-test-component-a.php
+++ b/tests/resources/views/livewire-test-component-a.php
@@ -12,6 +12,13 @@
     <x-button wire:click='singlequote' />
     <x-button wire:click="params({{$prop}}, 42)" />
     <a href="/test" wire:click.prevent="preventParams({{$prop}}, 42)">test</a>
+    <x-button wire:click="$refresh" />
+    <x-button wire:click="$toggle('sortAsc')" />
+    <x-button wire:click="$dispatch('post-created')" />
+    <x-button wire:click="search($event.target.value)" />
+    <x-button wire:click="$wire.$refresh()" />
+    <x-button wire:click="$parent.removePost({{ $post->id }})" />
+    <x-button wire:click="$set('query', '')" />
 
     <select wire:change="setSelector($event.target.value)">
         <option value="one">One</option>


### PR DESCRIPTION
Resolves #26.

Magic actions kind of already worked, but since they use some of the same tokens as regular expressions the method input needed to be escaped.

I added tests for each of the [magic action examples on the Livewire website](https://livewire.laravel.com/docs/actions#magic-actions). 