### PR TITLE
Fix `assertContainsLivewireComponent` for @livewire directive that is used on multiple line

### DIFF
--- a/src/CustomLivewireAssertionsMixin.php
+++ b/src/CustomLivewireAssertionsMixin.php
@@ -221,7 +221,7 @@ class CustomLivewireAssertionsMixin
             $componentHaystackView = file_get_contents($this->lastState->getView()->getPath());
 
             PHPUnit::assertMatchesRegularExpression(
-                '/@livewire\(\''.$component.'\'|<livewire\:'.$component.'/',
+                '/@livewire\(\s*\''.$component.'\'|<livewire\:'.$component.'/',
                 $componentHaystackView
             );
 

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -286,6 +286,7 @@ class AssertionsTest extends TestCase
     public function it_checks_if_it_sees_a_blade_directive(): void
     {
         Livewire::test(LivewireTestComponentC::class)
+            ->assertContainsLivewireComponent(LivewireTestComponentA::class)
             ->assertContainsLivewireComponent(LivewireTestComponentB::class);
     }
 

--- a/tests/resources/views/livewire-test-component-c.php
+++ b/tests/resources/views/livewire-test-component-c.php
@@ -1,3 +1,6 @@
 <div>
-    @livewire('tests.components.livewire-test-component-b')
+    @livewire('tests.components.livewire-test-component-a')
+    @livewire(
+        'tests.components.livewire-test-component-b'
+    )
 </div>


### PR DESCRIPTION
When using this example, `assertContainsLivewireComponent` will mark the test as failed, even though it's valid.

```php
@liveiwre(
    'create-post', 
    ['post' => $post, 'index' => 1],
    key($post->id)
)
```

I updated the regex for `assertContainsLivewireComponent` to also check for whitespaces after "(". 