### PR TITLE
fix: livewire finder resolution for contained component assertions

### DIFF
--- a/src/CustomLivewireAssertionsMixin.php
+++ b/src/CustomLivewireAssertionsMixin.php
@@ -5,7 +5,6 @@ namespace Christophrumpel\MissingLivewireAssertions;
 use Closure;
 use Illuminate\Support\Str;
 use Livewire\Component;
-use Livewire\Finder\Finder;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 /**
@@ -245,7 +244,7 @@ class CustomLivewireAssertionsMixin
     {
         return function (string $component) {
             if (is_subclass_of($component, Component::class)) {
-                $component = app(Finder::class)->normalizeName($component);
+                $component = app('livewire.finder')->normalizeName($component);
             }
 
             $componentHaystackView = file_get_contents($this->lastState->getView()->getPath());

--- a/src/CustomLivewireAssertionsMixin.php
+++ b/src/CustomLivewireAssertionsMixin.php
@@ -265,7 +265,7 @@ class CustomLivewireAssertionsMixin
     {
         return function (string $component) {
             if (is_subclass_of($component, Component::class)) {
-                $component = app(Finder::class)->normalizeName($component);
+                $component = app('livewire.finder')->normalizeName($component);
             }
 
             $componentHaystackView = file_get_contents($this->lastState->getView()->getPath());

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -4,6 +4,7 @@ use \Tests\NonExistantButton;
 use \Tests\NonExistantLivewireTestComponent;
 use Livewire\Livewire;
 use Tests\Components\FileDownloadComponent;
+use Tests\Components\ConfiguredNamespaceParentComponent;
 use Tests\Components\LivewireTestComponentA;
 use Tests\Components\LivewireTestComponentB;
 use Tests\Components\LivewireTestComponentC;
@@ -267,6 +268,14 @@ it(
             ->assertContainsLivewireComponent('tests.components.livewire-test-component-b');
     }
 );
+
+it('checks if Livewire component contains another component using configured class namespace', function () {
+    config()->set('livewire.class_namespace', 'Tests\\Components');
+    app()->forgetInstance('livewire.finder');
+
+    Livewire::test(ConfiguredNamespaceParentComponent::class)
+        ->assertContainsLivewireComponent(LivewireTestComponentB::class);
+});
 
 it(
     'checks if Livewire component does not contain another livewire component by component name',

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -277,6 +277,14 @@ it('checks if Livewire component contains another component using configured cla
         ->assertContainsLivewireComponent(LivewireTestComponentB::class);
 });
 
+it('checks if Livewire component does not contain another component using configured class namespace', function () {
+    config()->set('livewire.class_namespace', 'Tests\\Components');
+    app()->forgetInstance('livewire.finder');
+
+    Livewire::test(ConfiguredNamespaceParentComponent::class)
+        ->assertDoesNotContainLivewireComponent(LivewireTestComponentA::class);
+});
+
 it(
     'checks if Livewire component does not contain another livewire component by component name',
     function () {

--- a/tests/Components/ConfiguredNamespaceParentComponent.php
+++ b/tests/Components/ConfiguredNamespaceParentComponent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Components;
+
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+
+class ConfiguredNamespaceParentComponent extends Component
+{
+    public function render(): View
+    {
+        return view('configured-namespace-parent-component');
+    }
+}

--- a/tests/resources/views/configured-namespace-parent-component.php
+++ b/tests/resources/views/configured-namespace-parent-component.php
@@ -1,0 +1,3 @@
+<div>
+    <livewire:livewire-test-component-b />
+</div>


### PR DESCRIPTION
## Summary

This PR fixes namespaced component resolution in both `assertContainsLivewireComponent()` and `assertDoesNotContainLivewireComponent()` when Livewire components are resolved through a configured class namespace such as `App\Livewire`.

In Livewire 4, the finder is not just a plain helper class. Livewire registers a configured finder singleton in the container as `livewire.finder`, and during registration it adds the component class namespace from `config('livewire.class_namespace')` as well as any additional component namespaces. Livewire then uses that configured finder to normalize component class names into the component names used in Blade tags and directives.

These assertions were resolving class-based components with a fresh `Finder` instance via `app(Finder::class)`. That creates a new finder instead of reusing Livewire's configured singleton. Because that fresh instance does not know about the namespaces registered by Livewire, `normalizeName()` can return the wrong component name. For example, a component under the default `App\Livewire` namespace may be normalized as `app.livewire.component.index` instead of `component.index`.

## Changes

- use the container-bound Livewire finder via `app('livewire.finder')` in `assertContainsLivewireComponent()`
- use the same configured finder in `assertDoesNotContainLivewireComponent()`
- add regression coverage for both positive and negative assertions with `livewire.class_namespace` set to a configured namespace
- add a minimal fixture component and view to reproduce the namespaced resolution case

## Why this matters

These assertions are expected to follow the same component resolution rules as Livewire itself. Reusing `livewire.finder` is important because it carries the namespace configuration that Livewire registers at boot time. Without that, tests can fail or behave inconsistently even though the component usage is valid in a real application.

This change keeps the package aligned with Livewire 3 behavior, avoids false positives and false negatives, and improves compatibility for applications using the default namespace or custom component namespaces.

## Testing

Ran:

```bash
./vendor/bin/pest tests/AssertionsTest.php
```

## Notes
This is a focused bug fix with regression coverage and no intended public API change.

## References
- [Livewire Service Provider](https://github.com/livewire/livewire/blob/v4.2.2/src/LivewireServiceProvider.php#L35-L41)